### PR TITLE
Fixed model card data type

### DIFF
--- a/gollm/entities.py
+++ b/gollm/entities.py
@@ -20,7 +20,7 @@ class ModelCardModel(BaseModel):
 
 
 class ModelCompareModel(BaseModel):
-    cards: List # model cards
+    model_cards: List # model cards
 
 
 class EmbeddingModel(BaseModel):


### PR DESCRIPTION
# Description

Updated data type for the compare models input data type. 
There was a validation error occurring on model compare request since terrarium taskrunner sends the input payload with `{ model_cards: [...] }` while this service expects `{ cards: [...] }`. 
This change fixes the issue. 

Related PR: https://github.com/DARPA-ASKEM/terarium/pull/4024


Resolves #(issue)
