### PR TITLE
Added response format param

### DIFF
--- a/gollm/openai/tool_utils.py
+++ b/gollm/openai/tool_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 from openai import OpenAI, AsyncOpenAI
+from openai.types.chat.completion_create_params import ResponseFormat
 from typing import List
 from gollm.utils import (
     exceeds_tokens,
@@ -152,7 +153,7 @@ def condense_chain(query: str, chunks: List[str], max_tokens: int = 16385) -> st
     )
     return output.choices[0].message.content
 
-def generate_response(instruction: str) -> str:
+def generate_response(instruction: str, response_format: ResponseFormat | None = None) -> str:
     prompt = GENERAL_INSTRUCTION_PROMPT.format(instruction=instruction)
     client = OpenAI()
     output = client.chat.completions.create(
@@ -163,6 +164,7 @@ def generate_response(instruction: str) -> str:
 		temperature=0,
         seed=123,
         max_tokens=1024,
+        response_format=response_format,
         messages=[
             {"role": "user", "content": prompt},
         ],

--- a/gollm/openai/tool_utils.py
+++ b/gollm/openai/tool_utils.py
@@ -163,7 +163,7 @@ def generate_response(instruction: str, response_format: ResponseFormat | None =
         presence_penalty=0,
 		temperature=0,
         seed=123,
-        max_tokens=1024,
+        max_tokens=4000,
         response_format=response_format,
         messages=[
             {"role": "user", "content": prompt},

--- a/gollm/openai/tool_utils.py
+++ b/gollm/openai/tool_utils.py
@@ -163,7 +163,7 @@ def generate_response(instruction: str, response_format: ResponseFormat | None =
         presence_penalty=0,
 		temperature=0,
         seed=123,
-        max_tokens=4000,
+        max_tokens=2048,
         response_format=response_format,
         messages=[
             {"role": "user", "content": prompt},


### PR DESCRIPTION
# Description

Added response format parameter to `generate_response` so that user can specify the response type. 
e.g.  `response_format={"type": "json_object"}`

@mwdchang this will help to make sure the chart annotation response from the llm is formatted in json. 

Resolves #(issue)
